### PR TITLE
Update Readme to display well on Github

### DIFF
--- a/PHP SmartyPants Readme.txt
+++ b/PHP SmartyPants Readme.txt
@@ -24,7 +24,7 @@ SmartyPants can also be invoked as a standalone PHP function.
 SmartyPants can perform the following transformations:
 
 *   Straight quotes (`"` and `'`) into "curly" quote HTML entities
-*   Backtick-style quotes (` ``like this'' `) into "curly" quote HTML
+*   Backtick-style quotes (``` ``like this'' ```) into "curly" quote HTML
     entities
 *   Dashes (`--` and `---`) into en- and em-dash entities
 *   Three consecutive dots (`...`) into an ellipsis entity
@@ -199,10 +199,10 @@ Or inside a Smarty template:
     Educates normal quote characters: (`"`) and (`'`).
 
 "b"
-    Educates ` ``backticks'' ` double quotes.
+    Educates ``` ``backticks'' ``` double quotes.
 
 "B"
-    Educates backticks-style double quotes and ` `single' ` quotes.
+    Educates backticks-style double quotes and `` `single' `` quotes.
 
 "d"
     Educates em-dashes.


### PR DESCRIPTION
Hi, Michel

You said yesterday you would be interested in what was the Markdown code that didn't parse.  It is really minor.  You can see the example at the top of `Readme.md` in [this commit](https://github.com/rdancer/php-smartypants/tree/0b3fefe48b52f711843dfab6fba07be2e1e2f6fc); if you search for the string "like this", you will see it.

You said that you didn't want to rename the files, so I've reverted that.

Kind regards
Jan

---

When a code span contains backticks, [GitHub Flavoured Markdown](https://help.github.com/articles/github-flavored-markdown) would not parse it properly unless the surrounding backticks are doubled, or even tripled.  Example:

``````
Bad :   (1) ` `a` `     (2) ` ``b'' `
Good:   (1) `` `a` ``   (2) ``` ``b'' '''
``````
