### PR TITLE
Correct namespaces + Hack to load the temporary implementation class.

### DIFF
--- a/Michelf/SmartyPants.php
+++ b/Michelf/SmartyPants.php
@@ -10,7 +10,7 @@
 # Copyright (c) 2003-2004 John Gruber
 # <http://daringfireball.net/>
 #
-namespace michelf;
+namespace Michelf;
 
 
 ### Pre-Configured SmartyPants Modes ###
@@ -514,7 +514,7 @@ class SmartyPants {
 #
 # SmartyPants Typographer Parser Class
 #
-class _SmartyPantsTypographer_TmpImpl extends \michelf\SmartyPants {
+class _SmartyPantsTypographer_TmpImpl extends \Michelf\SmartyPants {
 
 	### Configuration Variables ###
 

--- a/Michelf/SmartyPantsTypographer.php
+++ b/Michelf/SmartyPantsTypographer.php
@@ -10,22 +10,27 @@
 # Copyright (c) 2003-2004 John Gruber
 # <http://daringfireball.net/>
 #
-namespace michelf;
+namespace Michelf;
+
+
+# Just force Michelf/SmartyPants.php to load. This is needed to load
+# the temporary implementation class. See below for details.
+\Michelf\SmartyPants::SMARTYPANTSLIB_VERSION;
 
 
 #
 # SmartyPants Typographer Parser Class
 #
 # Note: Currently the implementation resides in the temporary class
-# \michelf\_SmartyPantsTypographer_TmpImpl (in the same file as
-# \michelf\SmartyPants). This makes it easier to propagate the changes between
+# \Michelf\_SmartyPantsTypographer_TmpImpl (in the same file as
+# \Michelf\SmartyPants). This makes it easier to propagate the changes between
 # the three different packaging styles of PHP SmartyPants. Once this issue is
 # resolved, the _SmartyPantsTypographer_TmpImpl class will disappear and this
 # one will contain the code.
 #
-use \michelf\SmartyPants;
+use \Michelf\SmartyPants;
 
-class SmartyPantsTypographer extends \michelf\_SmartyPantsTypographer_TmpImpl {
+class SmartyPantsTypographer extends \Michelf\_SmartyPantsTypographer_TmpImpl {
 
 	### Parser Implementation ###
 


### PR DESCRIPTION
Hi.

Here two little corrections : 
- correction of namespaces : \michelf to \Michelf
- in SmartyPantsTypographer.php, add a hack to load the temporary implementation class (on the model of MarkdownExtra).

These corrections are necessary to use your library in PHP5 without modification.

Regards.
Mathieu Poisbeau
