### PR TITLE
Add an option 'G' to use German quotes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -218,6 +218,9 @@ ellipses or backticks-style quotes:
 	function:
 
         $my_html = SmartyPants::defaultTransform($my_html, "qDew");
+        
+"G"
+:   Use „German“ quotes instead of "English" quotes.
 
 
 ### Algorithmic Shortcomings ###


### PR DESCRIPTION
The configuration option 'G' can be set to use „German“ quotes instead of "English" quotes.
