### PR TITLE
Removed a irrelevant comment

### DIFF
--- a/Michelf/SmartyPants.php
+++ b/Michelf/SmartyPants.php
@@ -293,7 +293,6 @@ class SmartyPants {
 		$sq_close = $this->smart_singlequote_close;
 	
 		# Make our own "punctuation" character class, because the POSIX-style
-		# [:PUNCT:] is only available in Perl 5.6 or later:
 		$punct_class = "[!\"#\\$\\%'()*+,-.\\/:;<=>?\\@\\[\\\\\]\\^_`{|}~]";
 
 		# Special case if the very first character is a quote


### PR DESCRIPTION
Removed a comment about perl

Another thing...
Is `$punct_class = "[!\"#\\$\\%'()*+,-.\\/:;<=>?\\@\\[\\\\\]\\^_`{|}~]";` even relevant for the PHP version of this?